### PR TITLE
Add support for "encoding" parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function spawn(
 
     child.on('close', code => {
       activeProcesses.delete(child);
-      if (opts && opts.encoding) {
+      if (opts && opts.encoding && opts.encoding !== "buffer") {
         resolve({
           code,
           stdout: stdout.toString(opts.encoding),

--- a/test.js
+++ b/test.js
@@ -42,9 +42,16 @@ test('exit code 1', async t => {
   t.deepEqual(stderr, Buffer.from('some stderr'));
 });
 
-test('encoding', async t => {
+test('encoding: utf-8', async t => {
   let res = await spawn('node', [f.find('exit0.js')], { encoding: "utf-8" });
   t.is(res.code, 0);
   t.deepEqual(res.stdout, 'some stdout');
   t.deepEqual(res.stderr, 'some stderr');
+});
+
+test('encoding: buffer', async t => {
+  let res = await spawn('node', [f.find('exit0.js')], { encoding: "utf-8" });
+  t.is(res.code, 0);
+  t.deepEqual(res.stdout, Buffer.from('some stdout'));
+  t.deepEqual(res.stderr, Buffer.from('some stderr'));
 });


### PR DESCRIPTION
This adds support for the "encoding" parameter (from `spawnSync`).

See https://nodejs.org/api/child_process.html#child_process_child_process_spawnsync_command_args_options