### PR TITLE
Directly write the license in package.json for license management tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Take care of your `spawn()`",
   "author": "James Kyle <me@thejameskyle.com>",
   "repository": "https://github.com/thejameskyle/spawndamnit",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "MIT",
   "keywords": [
     "spawn",
     "child",


### PR DESCRIPTION
License management tools such as [License Finder](https://github.com/pivotal/LicenseFinder) mis-detect a license as "SEE LICENSE IN LICENSE", so I would like to want the license to be written directly in package.json.

The npm site also has the license as "SEE LICENSE IN LICENSE":

🔗 https://www.npmjs.com/package/spawndamnit

<img width="363" alt="spawndamnit on npm site" src="https://github.com/user-attachments/assets/62b6b804-e5b7-4df4-84e2-a8a53293dc85">
